### PR TITLE
Add parameter for generating complete heatmap (on all genes) if the c…

### DIFF
--- a/ScriptR/AskoR.R
+++ b/ScriptR/AskoR.R
@@ -72,6 +72,8 @@ Asko_start <- function(){
                           help="logFC in the summary table [default= %default]", metavar="logical"),
     optparse::make_option(c("--th_lfc"), type="double", default=0, dest="threshold_logFC",
                           help="logFC threshold [default= %default]", metavar="double"),
+    optparse::make_option("--CompleteHm", type="logical", default=FALSE, dest="CompleteHeatmap",
+                          help="generation of the normalized expression heatmap on ALL genes (TRUE/FALSE) [default= %default]", metavar="logical"),
     optparse::make_option("--fc", type="logical", default=TRUE, dest="FC",
                           help="FC in the summary table [default= %default]", metavar="logical"),
     optparse::make_option(c("--lcpm"), type="logical", default=FALSE, dest="logCPM",
@@ -864,7 +866,7 @@ GEnorm <- function(filtered_GE, asko_list, data_list, parameters){
 
   # heatmap visualisation
   #----------------------------------------------------
-  if(nrow(filtered_GE$counts) <= 30000)
+  if(parameters$CompleteHeatmap==TRUE)
   {
     # heatmap cpm value per sample
     #----------------------------------------------------

--- a/ScriptR/AskoR_analysis_script.R
+++ b/ScriptR/AskoR_analysis_script.R
@@ -34,6 +34,7 @@ parameters$threshold_logFC = 0                        # logFC threshold (default
 parameters$normal_method = "TMM"                      # normalization method (TMM/RLE/upperquartile/none) (default TMN)
 parameters$p_adj_method = "BH"                        # p-value adjust method (holm/hochberg/hommel/bonferroni/BH/BY/fdr/none) (default fdr)
 parameters$glm = "lrt"                                # GLM method (lrt/qlf) (default qlf)
+parameters$CompleteHeatmap = FALSE                    # Generate Complete heatmap on all normalized genes (default FALSE, select "TRUE" only if your have less 30000 genes and enough RAM on your computer)
 parameters$logFC = TRUE                               # logFC in the summary table (default TRUE)
 parameters$FC = TRUE                                  # FC in the summary table (default TRUE)
 parameters$logCPM = FALSE                             # logCPm in the summary table (default FALSE)


### PR DESCRIPTION
The complete heatmap of the expression (on all normalized genes) induced a bug on Galaxy and when the computer has not enough memory. So I create a parameter to select if the user want the heatmap (the default is FALSE) and I modify the condition to create the heatmap (before, the heatmap was created when the number of genes was under 30000 and now the heatmap is created only if "parameters$CompleteHeatmap" is set to TRUE). 
I've also inserted the line of this parameter in the analysis script.